### PR TITLE
Fix compilation and installation on ubuntu 22.04

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,17 +5,18 @@
 # SC_PYTHON_CONFIG is used to specify a custom python-config binary path
 # (Both must be python3, python2 is no longer supported)
 
+prefix          ?= usr
 TOP_DIR         := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))..)
 SRCDIR          := ${TOP_DIR}/src
 DOCSDIR         := ${TOP_DIR}/docs
 
 # These are used by "make tarball"
 DESTDIR         := $(TOP_DIR)/build_products/
-BIN_DIR         := usr/bin
-SBIN_DIR        := usr/sbin
-INC_DIR         := usr/include
-LIB_DIR         := usr/lib64
-DOC_DIR         := usr/share/doc
+BIN_DIR         := $(prefix)/bin
+SBIN_DIR        := $(prefix)/sbin
+INC_DIR         := $(prefix)/include
+LIB_DIR         := $(prefix)/lib64
+DOC_DIR         := $(prefix)/share/doc
 
 
 # Versioning:

--- a/src/Makefile
+++ b/src/Makefile
@@ -75,7 +75,7 @@ SC_LINK		:= -L$(SC_LIB) -Wl,-rpath,$(SC_BUILD)/$(SC_LIB) \
 SC_LINK		+= -lsolarcapture$(SC_VER_MAJ)
 
 CWARNINGS	:= -Wall -Wundef -Wstrict-prototypes -Wpointer-arith \
-		   -Wnested-externs -Wno-address-of-packed-member
+		   -Wnested-externs -Wno-address-of-packed-member -Wno-unused-result
 CXXWARNINGS	:= -Wall -Wundef -Wpointer-arith
 CFLAGS		:= -Werror $(CWARNINGS) -O2 -DNDEBUG
 CFLAGS_DBG	:= -Werror $(CWARNINGS) -rdynamic

--- a/src/components/sc_shm_broadcast.c
+++ b/src/components/sc_shm_broadcast.c
@@ -464,10 +464,12 @@ sc_shm_broadcast_handle_ssio_msg(struct sc_shm_broadcast_state* st,
       else {
         int rc = snprintf(resp->ssio_ringbuf_shm_path,
                           SSIO_MAX_STR_LEN,
+			  "%s",
                           sc_shm_endpoint_get_path(st->endpoints, endpoint_id));
         SC_TEST( rc < SSIO_MAX_STR_LEN );
         rc = snprintf(resp->ssio_buffer_shm_path,
-                      SSIO_MAX_STR_LEN, st->buffer_fname);
+                      SSIO_MAX_STR_LEN, "%s",
+		      st->buffer_fname);
         SC_TEST( rc < SSIO_MAX_STR_LEN );
       }
       pkt->iov[0].iov_len = sizeof(*out_hdr) + sizeof(*out_msg);

--- a/src/core/sc_debug.c
+++ b/src/core/sc_debug.c
@@ -21,7 +21,7 @@ static void sc_internal_error(struct sc_session* tg, const char* exp,
     "ERROR: SolarCapture detected internal error.  This may be due to a bug\n"
     "in SolarCapture, or in an application embedding SolarCapture, or in a\n"
     "plugin extension.\n";
-  sc_log(tg, msg);
+  sc_log(tg, "%s", msg);
   sc_log(tg, "ERROR: exp=%s in %s:%d\n", exp, func, line);
   sc_log(tg, "ERROR: context: %s %s %s\n", caller, ctx1, ctx2);
   abort();


### PR DESCRIPTION
Hi,

I have been trying to install solarcapture on ubuntu 22.04 (GCC 11) and there were a few compilation errors. This PR should fix those.

Also, I've allowed users to provide an installation prefix using the "prefix" environment variable with default to "usr".