### PR TITLE
fallocate fails beyond 4GiB

### DIFF
--- a/src/components/sc_perf_writer.c
+++ b/src/components/sc_perf_writer.c
@@ -618,7 +618,7 @@ static void sc_async_writer_submit_list(struct sc_node* node,
   struct iocb *iocbs_to_submit[MAX_SUBMIT];
 
   if( ((int64_t)(st->file_write_offset) > (int64_t)st->file_size - ALLOC_STRIDE/8 )) {
-    st->alloc_till = ALIGN_FWD(st->file_size + 1, ALLOC_STRIDE);
+    st->alloc_till = ALIGN_FWD(st->file_size + 1, (uint64_t)ALLOC_STRIDE);
     fallocate_fn(st->fd, 0, st->file_size, st->alloc_till - st->file_size);
     st->file_size = st->alloc_till;
   }


### PR DESCRIPTION
Cast ALLOC_STRIDE to uint64_t before aligning.  Without this cast, extending the output file wraps after the first 4GiB. The result of the ALIGN_FWD is treated as a 32-bit unsigned, and so the second argument to fallocate_fn is negative.