### PR TITLE
Fix detection of null string terminator in postrotate actions

### DIFF
--- a/src/solar_capture
+++ b/src/solar_capture
@@ -1196,7 +1196,7 @@ def read_str(fd):
     while True:
         try:
             b = os.read(fd,1)
-            if b[0] == '\0':
+            if b[0] == 0:
                 return rstr
             else:
                 rstr += b


### PR DESCRIPTION
When using a postrotate script, current head version doesn't execute it.  The detection of the null string terminator is broken.  

Tested on RHEL9, running 24/7 and rotating output every hour.


