### PR TITLE
Change location of adjustbox to remove loading error

### DIFF
--- a/docs/header.tex
+++ b/docs/header.tex
@@ -7,10 +7,10 @@
 \documentclass[twoside]{book}
 
 % Packages required by doxygen
+\usepackage[export]{adjustbox} % also loads graphicx
 \usepackage{fixltx2e}
 \usepackage{calc}
 \usepackage{doxygen}
-\usepackage[export]{adjustbox} % also loads graphicx
 \usepackage{graphicx}
 \usepackage[utf8]{inputenc}
 \usepackage{makeidx}


### PR DESCRIPTION
When building the docs on RHEL 9 I get the error
```
! LaTeX Error: Option clash for package adjustbox.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...

l.14 \usepackage
                {graphicx}
```

This is due to a double import of adjustbox
Moving the import of adjustbox to the top of the file fixes the error and the docs build without issue