### PR TITLE
remove distutils.sysconfig in favor of sysconfig

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -464,7 +464,7 @@ clean: pkg_clean
 .PHONY: install_python install_core install_live install_pro install_nonpython
 .PHONY: install_internal
 
-PY_SITE_DIR     := $$($(SC_PYTHON) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())" )
+PY_SITE_DIR     := $$($(SC_PYTHON) -c "import sysconfig; print(sysconfig.get_path('purelib'))" )
 
 py_sitelib_dir := $(DESTDIR)${PY_SITE_DIR}/solar_capture
 docdir    := $(DESTDIR)$(DOC_DIR)/solar_capture-$(SC_VER_STR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -464,7 +464,14 @@ clean: pkg_clean
 .PHONY: install_python install_core install_live install_pro install_nonpython
 .PHONY: install_internal
 
-PY_SITE_DIR     := $$($(SC_PYTHON) -c "import sysconfig; print(sysconfig.get_path('purelib'))" )
+PY_SITE_DIR := $(shell $(SC_PYTHON) -c "\
+import sys; \
+try: \
+    from distutils.sysconfig import get_python_lib; \
+    print(get_python_lib()); \
+except: \
+    import sysconfig; \
+    print(sysconfig.get_path('purelib'))")
 
 py_sitelib_dir := $(DESTDIR)${PY_SITE_DIR}/solar_capture
 docdir    := $(DESTDIR)$(DOC_DIR)/solar_capture-$(SC_VER_STR)

--- a/src/Makefile
+++ b/src/Makefile
@@ -464,14 +464,8 @@ clean: pkg_clean
 .PHONY: install_python install_core install_live install_pro install_nonpython
 .PHONY: install_internal
 
-PY_SITE_DIR := $(shell $(SC_PYTHON) -c "\
-import sys; \
-try: \
-    from distutils.sysconfig import get_python_lib; \
-    print(get_python_lib()); \
-except: \
-    import sysconfig; \
-    print(sysconfig.get_path('purelib'))")
+PY_SITE_DIR := $(shell $(SC_PYTHON) -c \
+  "exec(\"try:\n    import distutils.sysconfig as d,sys\n    sys.stdout.write(d.get_python_lib())\nexcept:\n    import sysconfig,sys\n    sys.stdout.write(sysconfig.get_path('purelib'))\")")
 
 py_sitelib_dir := $(DESTDIR)${PY_SITE_DIR}/solar_capture
 docdir    := $(DESTDIR)$(DOC_DIR)/solar_capture-$(SC_VER_STR)


### PR DESCRIPTION
Since [distutils](https://docs.python.org/3/library/distutils.html) is already deprecated in python 3.12, the original makefile might have some problems on newer linux system with python 3.13 shipped by default.