### PR TITLE
Ensure that install_igmp_filters is only ran once per iterface

### DIFF
--- a/src/solar_capture
+++ b/src/solar_capture
@@ -1188,9 +1188,9 @@ def install_mac_mcast_filter(intf, address):
     if err:
         err = os.system ("ethtool -U %s flow-type ether dst %s action 0" \
                          % (intf, mac))
-        sc.cli.err("Could not run ethtool to install filters (error %d).  "
+        sys.stderr.write("Could not run ethtool to install filters (error %d).  "
                    "Are you running solar_capture as root?  Is ethtool "
-                   "installed and in your path?" % (err >> 8))
+                   "installed and in your path?\n" % (err >> 8))
 
 # Cached so that this is only run once per interface
 @cache


### PR DESCRIPTION
On RHEL 9.6 and Onload 9.0.2 if you have multiple captures specified you get this error when running solar_capture:
```
SolarCapture 1.7.1.unknown.  Copyright (c) 2012-2019 Xilinx, Inc.
SolarCapture session=763801/0 log=/var/tmp/solar_capture_root_763801/0
rmgr: Cannot insert RX class rule: File exists
Cannot insert classification rule
ERROR: Could not run ethtool to install filters (error 1).  Are you running solar_capture as root?  Is ethtool installed and in your path?
```

The issue stems from having 2 sets of captures to run on the same interface `interface=foo join_stream="udp:bar" interface=foo join_stream="udp:baz"`

Running the ethtool command to create the same flow rule manually, returns `rmgr: Cannot insert RX class rule: File exists` which is expected and correct from the OS - you shouldn't be able to create duplicate rules

This change ensures that we only set the flow rules once to prevent this error